### PR TITLE
AN-2947/dex-vol-dupes

### DIFF
--- a/models/defillama/silver/silver__defillama_dex_volume.sql
+++ b/models/defillama/silver/silver__defillama_dex_volume.sql
@@ -72,7 +72,7 @@ FROM dex_base,
 SELECT
     chain,
     timestamp,
-    key::STRING AS protocol, 
+    LOWER(key::STRING) AS protocol, 
     value::INTEGER AS daily_volume,
     dex_object,
     _inserted_timestamp,


### PR DESCRIPTION
1. Added LOWER case on protocol to remove dupes
2. Requires FR+ on `silver__defillama_dex_volume`  after dropping in prod