### PR TITLE
AN-2945/bridge-names

### DIFF
--- a/models/defillama/bronze/bronze__defillama_bridges.sql
+++ b/models/defillama/bronze/bronze__defillama_bridges.sql
@@ -16,6 +16,7 @@ SELECT
 SELECT
     VALUE:id::STRING AS bridge_id,
     VALUE:name::STRING AS bridge,
+    VALUE:displayName::STRING AS bridge_name,
     VALUE:chains AS chains,
     CASE 
         WHEN VALUE:destinationChain::STRING ilike 'false' OR VALUE:destinationChain::STRING = '-' THEN NULL 

--- a/models/defillama/bronze/bronze__defillama_bridges.yml
+++ b/models/defillama/bronze/bronze__defillama_bridges.yml
@@ -1,6 +1,6 @@
 version: 2
 models:
-  - name: silver__defillama_bridges
+  - name: bronze__defillama_bridges
     tests:
       - dbt_utils.unique_combination_of_columns:
             combination_of_columns:

--- a/models/defillama/bronze/bronze__defillama_bridges.yml
+++ b/models/defillama/bronze/bronze__defillama_bridges.yml
@@ -13,6 +13,7 @@ models:
       - name: BRIDGE
         tests: 
           - not_null
+      - name: BRIDGE_NAME
       - name: CHAINS
       - name: DESTINATION_CHAIN
       - name: _INSERTED_TIMESTAMP

--- a/models/defillama/bronze/bronze__defillama_chains.yml
+++ b/models/defillama/bronze/bronze__defillama_chains.yml
@@ -1,6 +1,6 @@
 version: 2
 models:
-  - name: silver__defillama_chains
+  - name: bronze__defillama_chains
     tests:
       - dbt_utils.unique_combination_of_columns:
             combination_of_columns:

--- a/models/defillama/bronze/bronze__defillama_dexes.yml
+++ b/models/defillama/bronze/bronze__defillama_dexes.yml
@@ -1,6 +1,6 @@
 version: 2
 models:
-  - name: silver__defillama_dexes
+  - name: bronze__defillama_dexes
     tests:
       - dbt_utils.unique_combination_of_columns:
             combination_of_columns:

--- a/models/defillama/bronze/bronze__defillama_protocols.yml
+++ b/models/defillama/bronze/bronze__defillama_protocols.yml
@@ -1,6 +1,6 @@
 version: 2
 models:
-  - name: silver__defillama_protocols
+  - name: bronze__defillama_protocols
     tests:
       - dbt_utils.unique_combination_of_columns:
             combination_of_columns:

--- a/models/defillama/bronze/bronze__defillama_stablecoins.yml
+++ b/models/defillama/bronze/bronze__defillama_stablecoins.yml
@@ -1,6 +1,6 @@
 version: 2
 models:
-  - name: silver__defillama_stablecoins
+  - name: bronze__defillama_stablecoins
     tests:
       - dbt_utils.unique_combination_of_columns:
             combination_of_columns:

--- a/models/defillama/gold/defillama__dim_bridges.sql
+++ b/models/defillama/gold/defillama__dim_bridges.sql
@@ -15,6 +15,7 @@
 SELECT
     bridge_id,
     bridge,
+    bridge_name,
     chains,
     destination_chain
 FROM {{ ref('bronze__defillama_bridges') }}

--- a/models/defillama/gold/defillama__dim_bridges.yml
+++ b/models/defillama/gold/defillama__dim_bridges.yml
@@ -7,7 +7,9 @@ models:
       - name: BRIDGE_ID
         description: Unique identifier of the bridge.
       - name: BRIDGE
-        description: Name of the bridge.
+        description: The name of the listed bridge.
+      - name: BRIDGE_NAME
+        description: The more descriptive, official display name of the bridge.
       - name: CHAINS
         description: Array of the various chains or networks that the bridge interacts with.
       - name: DESTINATION_CHAIN

--- a/models/defillama/gold/defillama__fact_bridge_volume.sql
+++ b/models/defillama/gold/defillama__fact_bridge_volume.sql
@@ -16,6 +16,7 @@ SELECT
     TIMESTAMP :: DATE AS DATE,
     bridge_id,
     bridge,
+    bridge_name,
     deposit_txs,
     deposit_usd,
     withdraw_txs,

--- a/models/defillama/gold/defillama__fact_bridge_volume.yml
+++ b/models/defillama/gold/defillama__fact_bridge_volume.yml
@@ -10,6 +10,8 @@ models:
         description: Unique identifier of the bridge.
       - name: BRIDGE
         description: Name of the bridge.
+      - name: BRIDGE_NAME
+        description: The more descriptive, official display name of the bridge.
       - name: DEPOSIT_TXS
         description: Total number of deposit transactions to the bridge.
       - name: DEPOSIT_USD

--- a/models/defillama/silver/silver__defillama_bridge_volume.sql
+++ b/models/defillama/silver/silver__defillama_bridge_volume.sql
@@ -12,6 +12,7 @@ WITH bridge_base AS (
 SELECT
     bridge_id,
     bridge,
+    bridge_name,
     ethereum.streamline.udf_api(
         'GET',CONCAT('https://bridges.llama.fi/bridgevolume/all?id=',bridge_id),{},{}
     ) AS read,
@@ -20,6 +21,7 @@ FROM (
     SELECT 
         bridge_id,
         bridge,
+        bridge_name,
         row_num
     FROM {{ ref('bronze__defillama_bridges') }}
     WHERE row_num BETWEEN {{ item * 10 + 1 }} AND {{ (item + 1) * 10}}
@@ -47,6 +49,7 @@ UNION ALL
 SELECT
     bridge_id,
     bridge,
+    bridge_name,
     TO_TIMESTAMP(VALUE:date::INTEGER) AS timestamp,
     VALUE:depositTxs::INTEGER AS deposit_txs,
     VALUE:depositUSD::INTEGER AS deposit_usd,
@@ -55,4 +58,4 @@ SELECT
     _inserted_timestamp,
     CONCAT(bridge_id,'-',bridge,'-',timestamp) AS id
 FROM bridge_base,
-    LATERAL FLATTEN (input=> read:data) 
+    LATERAL FLATTEN (input=> read:data)


### PR DESCRIPTION
1. Added `bridge_name` column for analysis/clarification purposes
2. Requires FR on `bronze__defillama_bridges` (table drop not required)
3. Requires FR+ on `silver__defillama_bridge_volume` after dropping in prod