### PR TITLE
AN-3041/defillama-request-fail

### DIFF
--- a/models/defillama/bronze/bronze__defillama_chains.sql
+++ b/models/defillama/bronze/bronze__defillama_chains.sql
@@ -11,13 +11,13 @@ SELECT
         'GET','https://api.llama.fi/chains',{},{}
     ) AS read,
     SYSDATE() AS _inserted_timestamp
-)
+),
 
+FINAL AS (
 SELECT
     VALUE:chainId::STRING AS chain_id,
     VALUE:name::STRING AS chain,
     VALUE:tokenSymbol::STRING AS token_symbol,
-    ROW_NUMBER() OVER (ORDER BY chain) AS row_num,
     _inserted_timestamp
 FROM chain_base,
     LATERAL FLATTEN (input=> read:data)
@@ -29,4 +29,29 @@ WHERE chain NOT IN (
     FROM
         {{ this }}
 )
+)
+
+SELECT
+    chain_id,
+    chain,
+    token_symbol,
+    m.row_num + ROW_NUMBER() OVER (ORDER BY chain) AS row_num,
+    _inserted_timestamp
+FROM FINAL
+JOIN (
+    SELECT
+        MAX(row_num) AS row_num
+    FROM
+        {{ this }}
+) m ON 1=1
+
+{% else %}
+)
+SELECT
+    chain_id,
+    chain,
+    token_symbol,
+    ROW_NUMBER() OVER (ORDER BY chain) AS row_num,
+    _inserted_timestamp
+FROM FINAL
 {% endif %}

--- a/models/defillama/silver/silver__defillama_bridge_volume.sql
+++ b/models/defillama/silver/silver__defillama_bridge_volume.sql
@@ -33,7 +33,7 @@ WHERE bridge_id NOT IN (
     FROM (
         SELECT 
             DISTINCT bridge_id,
-            MAX(COALESCE(timestamp::DATE,CURRENT_DATE::TIMESTAMP)) AS max_timestamp
+            MAX(timestamp::DATE) AS max_timestamp
         FROM {{ this }}
         GROUP BY 1
         HAVING CURRENT_DATE = max_timestamp
@@ -50,7 +50,7 @@ SELECT
     bridge_id,
     bridge,
     bridge_name,
-    COALESCE(TO_TIMESTAMP(VALUE:date::INTEGER),CURRENT_DATE::TIMESTAMP) AS timestamp,
+    TO_TIMESTAMP(VALUE:date::INTEGER) AS timestamp,
     VALUE:depositTxs::INTEGER AS deposit_txs,
     VALUE:depositUSD::INTEGER AS deposit_usd,
     VALUE:withdrawTxs::INTEGER AS withdraw_txs,
@@ -59,5 +59,3 @@ SELECT
     CONCAT(bridge_id,'-',bridge,'-',timestamp) AS id
 FROM bridge_base,
     LATERAL FLATTEN (input=> read:data)
-WHERE deposit_txs IS NOT NULL
-    OR withdraw_txs IS NOT NULL

--- a/models/defillama/silver/silver__defillama_chains_tvl.sql
+++ b/models/defillama/silver/silver__defillama_chains_tvl.sql
@@ -23,6 +23,8 @@ FROM (
         row_num
     FROM {{ ref('bronze__defillama_chains') }}
     WHERE row_num BETWEEN {{ item * 60 + 1 }} AND {{ (item + 1) * 60 }}
+        AND chain NOT IN ('Regen')
+        --exclude chains with response size > 6mb
     )
 {% if is_incremental() %}
 WHERE chain NOT IN (


### PR DESCRIPTION
1. Excluded chain from `silver.defillama_chains_tvl` due to response size, resolving request failure
2. Added incremental logic to bronze tables to resolve issue with duplicate `row_num` on incremental loads