### PR TITLE
pool_yields_inc_fix 

### DIFF
--- a/models/defillama/silver/silver__defillama_pool_yields.sql
+++ b/models/defillama/silver/silver__defillama_pool_yields.sql
@@ -1,6 +1,5 @@
 {{ config(
     materialized = 'incremental',
-    full_refresh = false,
     unique_key = 'defillama_yield_id',
     tags = ['defillama']
 ) }}
@@ -101,6 +100,7 @@ SELECT
     ) }} AS defillama_yield_id,
     SYSDATE() AS inserted_timestamp,
     SYSDATE() AS modified_timestamp,
+    _inserted_timestamp,
     '{{ invocation_id }}' AS _invocation_id
 FROM
     FINAL

--- a/models/defillama/silver/silver__defillama_pool_yields.sql
+++ b/models/defillama/silver/silver__defillama_pool_yields.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
     unique_key = 'defillama_yield_id',
+    full_refresh = false,
     tags = ['defillama']
 ) }}
 

--- a/models/defillama/silver/silver__defillama_pool_yields.sql
+++ b/models/defillama/silver/silver__defillama_pool_yields.sql
@@ -1,7 +1,6 @@
 {{ config(
     materialized = 'incremental',
     unique_key = 'defillama_yield_id',
-    full_refresh = false,
     tags = ['defillama']
 ) }}
 


### PR DESCRIPTION
`dbt run -m models/defillama/silver/silver__defillama_pool_yields.sql+ --full-refresh`

Will require `DROP TABLE external.silver.defillama_pool_yields;` on prod DB before running the dbt command.